### PR TITLE
Introduce `nightly` crate feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        include:
+          - rust: stable
+            features: ""
+          - rust: nightly-2021-04-15
+            features: "nightly"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -54,36 +62,38 @@ jobs:
         uses: actions/cache@v1
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-build-target
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
 
       - name: Format
         uses: actions-rs/cargo@v1
+        if: matrix.rust == 'stable'
         with:
           command: fmt
           args: --all -- --check
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         with:
+          name: "Clippy (features: ${{ matrix.features }})"
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-targets -- -D warnings
+          args: --all --features=${{ matrix.features }} --all-targets -- -D warnings
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --all-targets
+          args: --all --features=${{ matrix.features }} --all-targets
       - name: Run doc tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --all-features --doc
+          args: --all --features=${{ matrix.features }} --doc
 
   # Checks that the crate actually builds without `std`. To do this,
   # we take a target (`thumbv7m-none-eabi`) that does not have `std` support.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ hex = "0.4.3"
 pem = "0.8.3"
 rand = "0.8.3"
 version-sync = "0.9.2"
+
+[features]
+# Enables unstable Rust features to produce clearer panic messages.
+# Requires a nightly Rust toolchain.
+nightly = []


### PR DESCRIPTION
...in order to conditionally use `assert!` macros in the const context (obviously, this works in nightly Rust only). Also, panic messages are slightly improved.