### PR TITLE
Infer output length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- Add `decode!` macro that allows to skip specifying output length.
+- Make panic messages more informative by including context information.
+
 ### Changed
 
 - Bump MSRV to 1.66.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,11 +36,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "compile-fmt"
+version = "0.1.0"
+
+[[package]]
 name = "const-decoder"
 version = "0.3.0"
 dependencies = [
  "base64",
  "bech32",
+ "compile-fmt",
  "doc-comment",
  "hex",
  "pem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "compile-fmt"
 version = "0.1.0"
+source = "git+https://github.com/slowli/compile-fmt.git?rev=0f0c1ab3e90c854beede0ceaa87ce0d96e209a7f#0f0c1ab3e90c854beede0ceaa87ce0d96e209a7f"
 
 [[package]]
 name = "const-decoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = ["encoding", "no-std"]
 description = "Constant functions for converting hex- and base64-encoded strings into bytes"
 repository = "https://github.com/slowli/const-decoder"
 
+[dependencies]
+compile-fmt = { path = "../compile-fmt" }
+
 [dev-dependencies]
 base64 = "0.21.0"
 bech32 = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ categories = ["encoding", "no-std"]
 description = "Constant functions for converting hex- and base64-encoded strings into bytes"
 repository = "https://github.com/slowli/const-decoder"
 
-[dependencies]
-compile-fmt = { path = "../compile-fmt" }
+[dependencies.compile-fmt]
+git = "https://github.com/slowli/compile-fmt.git"
+version = "0.1.0"
+rev = "0f0c1ab3e90c854beede0ceaa87ce0d96e209a7f"
 
 [dev-dependencies]
 base64 = "0.21.0"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ const SECRET_KEY: [u8; 64] = Decoder::Hex.decode(
     b"9e55d1e1aa1f455b8baad9fdf975503655f8b359d542fa7e4ce84106d625b352\
       06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075",
 );
+// Alternatively, you can use `decode!` macro:
+const PUBLIC_KEY: &[u8] = &const_decoder::decode!(
+    Decoder::Hex,
+    b"06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075",
+);
 ```
 
 [Bech32] encoding:

--- a/deny.toml
+++ b/deny.toml
@@ -31,3 +31,7 @@ allow-wildcard-paths = true
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = [
+  # Temporarily allow relying on an unpiblished version of `compile-fmt`
+  "https://github.com/slowli/compile-fmt.git",
+]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -63,7 +63,7 @@ impl Encoding {
             let byte = alphabet_bytes[index];
             compile_assert!(
                 byte < 0x80,
-                "Alphabet '", alphabet => clip(64, ""), "' contains non-ASCII character at ",
+                "Alphabet '", alphabet => clip(64, ""), "' contains non-ASCII character at position ",
                 index => fmt::<usize>()
             );
             let byte_idx = byte as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,12 +94,14 @@
 #![allow(clippy::must_use_candidate, clippy::shadow_unrelated)]
 
 mod decoder;
+mod macros;
 #[cfg(test)]
 mod tests;
 mod wrappers;
 
 pub use crate::{
     decoder::{Decoder, Encoding},
+    macros::DecoderWrapper,
     wrappers::{Pem, SkipWhitespace},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,14 +6,11 @@
 //! and [`Pem`] types providing its variations with slightly different properties.
 //! (For example, `Pem` allows to parse PEM files.)
 //!
+//! Methods in base types require specifying the length of the output byte array, either in its type,
+//! or using the turbofish syntax (see the examples below). To avoid this, you can instead use
+//! the [`decode!`] macro.
+//!
 //! Conversions are primarily useful for testing, but can be used in other contexts as well.
-//!
-//! # Limitations
-//!
-//! - Length of the output byte array needs to be specified, either in its type, or using
-//!   turbofish syntax (see the examples below). This could be seen as a positive in some cases;
-//!   e.g., keys in cryptography frequently have an expected length, and specifying it can prevent
-//!   key mix-up.
 //!
 //! # Alternatives
 //!
@@ -40,15 +37,29 @@
 //! );
 //! ```
 //!
-//! [`include_bytes!`] macro works as well, although it is necessary to specify bytes length.
+//! Same input string decoded using [`decode!`]:
 //!
 //! ```
-//! # use const_decoder::Pem;
+//! use const_decoder::{decode, Decoder};
+//!
+//! const SECRET_KEY: &[u8] = &decode!(
+//!     Decoder::Hex,
+//!     b"9e55d1e1aa1f455b8baad9fdf975503655f8b359d542fa7e4ce84106d625b352\
+//!       06fac1f22240cffd637ead6647188429fafda9c9cb7eae43386ac17f61115075",
+//! );
+//! ```
+//!
+//! Note how specifying the output length is avoided by placing the `decode!` output behind a reference.
+//!
+//! [`include_bytes!`] macro works as well.
+//!
+//! ```
+//! # use const_decoder::{decode, Pem};
 //! # // We don't actually want to access FS in tests, so we hack the `include_bytes` macro.
 //! # macro_rules! include_bytes {
 //! #     ($path:tt) => { &[b'A'; 1184] };
 //! # }
-//! const CERT: &[u8] = &Pem::decode::<888>(include_bytes!("certificate.crt"));
+//! const CERT: &[u8] = &decode!(Pem, include_bytes!("certificate.crt"));
 //! ```
 //!
 //! Naturally, all code works in the runtime context as well.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,50 @@
+//! `decode!` macro and the associated helper types.
+
+#![allow(missing_docs)] // FIXME
+
+use crate::{
+    decoder::Decoder,
+    wrappers::{Pem, SkipWhitespace, Skipper},
+};
+
+#[macro_export]
+macro_rules! decode {
+    ($decoder:expr, $bytes:expr $(,)?) => {{
+        const __OUTPUT_LEN: usize = $crate::DecoderWrapper($decoder).decode_len($bytes);
+        $crate::DecoderWrapper($decoder).decode::<__OUTPUT_LEN>($bytes) as [u8; __OUTPUT_LEN]
+    }};
+}
+
+#[derive(Debug)]
+pub struct DecoderWrapper<T>(pub T);
+
+impl DecoderWrapper<Decoder> {
+    pub const fn decode_len(&self, input: &[u8]) -> usize {
+        self.0.do_decode_len(input, None)
+    }
+
+    pub const fn decode<const N: usize>(self, input: &[u8]) -> [u8; N] {
+        self.0.decode(input)
+    }
+}
+
+impl DecoderWrapper<SkipWhitespace> {
+    pub const fn decode_len(&self, input: &[u8]) -> usize {
+        let Self(SkipWhitespace(decoder)) = self;
+        decoder.do_decode_len(input, Some(Skipper::Whitespace))
+    }
+
+    pub const fn decode<const N: usize>(self, input: &[u8]) -> [u8; N] {
+        self.0.decode(input)
+    }
+}
+
+impl DecoderWrapper<Pem> {
+    pub const fn decode_len(&self, input: &[u8]) -> usize {
+        Decoder::Base64.do_decode_len(input, Some(Skipper::Pem))
+    }
+
+    pub const fn decode<const N: usize>(self, input: &[u8]) -> [u8; N] {
+        Pem::decode(input)
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,12 +1,54 @@
 //! `decode!` macro and the associated helper types.
 
-#![allow(missing_docs)] // FIXME
-
 use crate::{
     decoder::Decoder,
     wrappers::{Pem, SkipWhitespace, Skipper},
 };
 
+/// Computes the output length in compile time and decodes the input. This allows to skip specifying
+/// output length manually.
+///
+/// The macro accepts two comma-separate expressions. The first arg must evaluate to [`Decoder`],
+/// [`SkipWhitespace`], or [`Pem`]. The second argument must evaluate to `&[u8]`. Both expressions
+/// must be assignable to constants. The output of a macro is an array `[u8; N]` with the decoded bytes.
+///
+/// # Examples
+///
+/// ## Usage with `Decoder`s
+///
+/// ```
+/// use const_decoder::{decode, Decoder};
+///
+/// const HEX: &[u8] = &decode!(Decoder::Hex, b"c0ffee");
+/// const BASE64: &[u8] = &decode!(Decoder::Base64, b"VGVzdCBzdHJpbmc=");
+/// // Can be used with custom decoders as well
+/// const BASE32: &[u8] = &decode!(
+///     Decoder::custom("qpzry9x8gf2tvdw0s3jn54khce6mua7l"),
+///     b"rp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q",
+/// );
+/// ```
+///
+/// ## Usage with `SkipWhitespace`
+///
+/// ```
+/// # use const_decoder::{decode, Decoder};
+/// const HEX: &[u8] = &decode!(
+///     Decoder::Hex.skip_whitespace(),
+///     b"c0ff ee00 beef",
+/// );
+/// ```
+///
+/// ## Usage with `Pem`
+///
+/// ```
+/// # use const_decoder::{decode, Pem};
+/// const PRIVATE_KEY: &[u8] = &decode!(
+///     Pem,
+///     b"-----BEGIN PRIVATE KEY-----
+///       MC4CAQAwBQYDK2VuBCIEINAOV4yAyaoM2wmJPApQs3byDhw7oJRG47V0VHwGnctD
+///       -----END PRIVATE KEY-----",
+/// );
+/// ```
 #[macro_export]
 macro_rules! decode {
     ($decoder:expr, $bytes:expr $(,)?) => {{
@@ -16,6 +58,7 @@ macro_rules! decode {
 }
 
 #[derive(Debug)]
+#[doc(hidden)] // implementation detail of the `decode!` macro
 pub struct DecoderWrapper<T>(pub T);
 
 impl DecoderWrapper<Decoder> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -73,9 +73,21 @@ fn base64_codec_in_runtime() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Character '-' is not present in the alphabet")]
 fn mixed_base64_alphabet_leads_to_panic() {
     Decoder::Base64.decode::<6>(b"Pj4-Pz8/");
+}
+
+#[test]
+#[should_panic(expected = "input decodes to 6 bytes, while type inference implies 3.")]
+fn input_length_overflow() {
+    Decoder::Base64.decode::<3>(b"Pj4+Pz8/");
+}
+
+#[test]
+#[should_panic(expected = "input decodes to 6 bytes, while type inference implies 16.")]
+fn input_length_underflow() {
+    Decoder::Base64.decode::<16>(b"Pj4+Pz8/");
 }
 
 const BECH32: Decoder = Decoder::custom("qpzry9x8gf2tvdw0s3jn54khce6mua7l");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,6 +103,24 @@ fn mixed_base64_alphabet_leads_to_panic() {
 }
 
 #[test]
+#[should_panic(expected = "Invalid alphabet length 5; must be one of 2, 4, 8, 16, 32, or 64")]
+fn invalid_alphabet_length() {
+    Decoder::custom("what?");
+}
+
+#[test]
+#[should_panic(expected = "Alphabet 'teß' contains non-ASCII character at position 2")]
+fn non_ascii_char_in_alphabet() {
+    Decoder::custom("teß");
+}
+
+#[test]
+#[should_panic(expected = "Alphabet character 'a' is mentioned several times")]
+fn duplicate_char_in_alphabet() {
+    Decoder::custom("alphabet");
+}
+
+#[test]
 #[should_panic(expected = "input decodes to 6 bytes, while type inference implies 3.")]
 fn input_length_overflow() {
     Decoder::Base64.decode::<3>(b"Pj4+Pz8/");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -97,7 +97,7 @@ fn base64_codec_in_runtime() {
 }
 
 #[test]
-#[should_panic(expected = "Character '-' is not present in the alphabet")]
+#[should_panic(expected = "Character '-' at position 3 is not a part of the decoder alphabet")]
 fn mixed_base64_alphabet_leads_to_panic() {
     Decoder::Base64.decode::<6>(b"Pj4-Pz8/");
 }
@@ -109,7 +109,7 @@ fn invalid_alphabet_length() {
 }
 
 #[test]
-#[should_panic(expected = "Alphabet 'teß' contains non-ASCII character at position 2")]
+#[should_panic(expected = "String 'teß' contains non-ASCII chars; first at position 2")]
 fn non_ascii_char_in_alphabet() {
     Decoder::custom("teß");
 }
@@ -118,6 +118,18 @@ fn non_ascii_char_in_alphabet() {
 #[should_panic(expected = "Alphabet character 'a' is mentioned several times")]
 fn duplicate_char_in_alphabet() {
     Decoder::custom("alphabet");
+}
+
+#[test]
+#[should_panic(expected = "Non-ASCII character with decimal code 223")]
+fn non_ascii_input() {
+    Decoder::Base64.decode::<6>(b"P\xDF+Pz8/");
+}
+
+#[test]
+#[should_panic(expected = "Character 'u' at position 7 is not a hex digit")]
+fn invalid_char_in_hex_input() {
+    Decoder::Hex.decode::<4>(b"c0ffeecu");
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,6 +9,12 @@ fn hex_codec() {
 }
 
 #[test]
+fn hex_codec_with_macro() {
+    const KEY: &[u8] = &decode!(Decoder::Hex, b"1234567f");
+    assert_eq!(KEY, [0x12, 0x34, 0x56, 0x7f]);
+}
+
+#[test]
 #[should_panic]
 fn hex_encoding_with_odd_number_of_digits() {
     let _: [u8; 1] = Decoder::Hex.decode(b"012");
@@ -18,6 +24,18 @@ fn hex_encoding_with_odd_number_of_digits() {
 fn hex_codec_with_whitespace() {
     const KEY: [u8; 4] = Decoder::Hex.skip_whitespace().decode(b"12\n34  56\t7f");
     assert_eq!(KEY, [0x12, 0x34, 0x56, 0x7f]);
+}
+
+#[test]
+fn skipping_whitespace_with_macro() {
+    const KEY: &[u8] = &decode!(
+        Decoder::Hex.skip_whitespace(),
+        b"01234567  89abcdef \
+          fedcba98  76543210",
+    );
+    assert_eq!(KEY.len(), 16);
+    assert_eq!(KEY[0], 1);
+    assert_eq!(KEY[15], 0x10);
 }
 
 #[test]
@@ -36,6 +54,12 @@ fn base64_codec_in_compile_time() {
     for &(actual, expected) in SAMPLES {
         assert_eq!(actual, expected);
     }
+}
+
+#[test]
+fn base64_codec_with_macro() {
+    const TEST: &[u8] = &decode!(Decoder::Base64, b"VGVzdCBzdHJpbmc=");
+    assert_eq!(TEST, b"Test string");
 }
 
 #[test]
@@ -112,6 +136,15 @@ fn bech32_encoding() {
 }
 
 #[test]
+fn bech32_codec_with_macro() {
+    const TEST: &[u8] = &decode!(BECH32, b"w508d6qejxtdg4y5r3zarvary0c5xw7k");
+    assert_eq!(
+        TEST,
+        decode!(Decoder::Hex, b"751e76e8199196d454941c45d1b3a323f1433bd6")
+    );
+}
+
+#[test]
 #[should_panic]
 fn bech32_encoding_with_invalid_padding() {
     // The last char `l = 31` is too large.
@@ -133,4 +166,10 @@ fn octal_encoding() {
     const BASE8: Decoder = Decoder::custom("01234567");
     assert_eq!(BASE8.decode::<1>(b"766"), [0o_76 * 4 + 3]);
     assert_eq!(BASE8.decode::<3>(b"35145661"), [116, 203, 177]);
+}
+
+#[test]
+fn octal_codec_in_macro() {
+    const TEST: &[u8] = &decode!(Decoder::custom("01234567"), b"35145661");
+    assert_eq!(TEST, [116, 203, 177]);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,15 +5,15 @@ use base64::{
 use bech32::{ToBase32, Variant};
 use rand::{thread_rng, RngCore};
 
-use const_decoder::{Decoder, Pem};
+use const_decoder::{decode, Decoder, Pem};
 
 #[test]
 fn reading_from_file_works() {
     const RAW_INPUT: &[u8] = include_bytes!("certificate.crt");
-    const CERT: [u8; 888] = Pem::decode(RAW_INPUT);
+    const CERT: &[u8] = &decode!(Pem, RAW_INPUT);
 
     let parsed = pem::parse(RAW_INPUT).unwrap();
-    assert_eq!(CERT, *parsed.contents());
+    assert_eq!(CERT, parsed.contents());
 }
 
 fn fuzz_hex_decoder<const N: usize>(samples: usize) {


### PR DESCRIPTION
- Adds `decode!` macro that allows to skip specifying output length.
- Makes panic messages more informative by including context information.

closes #12